### PR TITLE
Type hints, optional sparse output, stdin as input

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 Copyright (c) 2019-2020 Jan Wolff
+                   2024 Jarno Elonen
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages


### PR DESCRIPTION
This PR implements several improvements:

- Add Python type hints
- Remove seeking of input, making it possible to use `/dev/stdin` (e.g. zstdcat pipe) as an input (fixes #3)
- Optionally write output as sparse files instead of filling explicitly with zeros. Zero-fill is default, however, as I've recently encoutered some odd integrity issues with sparse VMA extracts on CephFS

It has so far always produced identical output to the original  PVE `vma` command, but it's really hard to be 100% sure as the VMA format unfortunately doesn't have checksums for the device image contents, only the file headers.